### PR TITLE
Enhancements to Tailwind Class Generation and Figma Plugin Updates

### DIFF
--- a/apps/plugin/plugin-src/code.ts
+++ b/apps/plugin/plugin-src/code.ts
@@ -83,9 +83,17 @@ const safeRun = (settings: PluginSettings) => {
 const standardMode = async () => {
   figma.showUI(__html__, { width: 450, height: 550, themeColors: true });
   await initSettings();
+  
+  // Listen for selection changes
   figma.on("selectionchange", () => {
     safeRun(userPluginSettings);
   });
+
+  // Listen for document changes
+  figma.on("documentchange", () => {
+    safeRun(userPluginSettings);
+  });
+
   figma.ui.onmessage = (msg) => {
     console.log("[node] figma.ui.onmessage", msg);
 

--- a/packages/backend/src/tailwind/conversionTables.ts
+++ b/packages/backend/src/tailwind/conversionTables.ts
@@ -114,7 +114,7 @@ export const nearestColorFromRgb = (color: RGB) => {
 }
 
 export const variableToColorName = (alias: VariableAlias) => {
-  return figma.variables.getVariableById(alias.id)?.name.replaceAll("/", "-") || alias.id.toLowerCase().replaceAll(":", "-");
+  return figma.variables.getVariableById(alias.id)?.name.replaceAll("/", "-").replaceAll(" ", "-") || alias.id.toLowerCase().replaceAll(":", "-");
 };
 
 /**

--- a/packages/backend/src/tailwind/tailwindMain.ts
+++ b/packages/backend/src/tailwind/tailwindMain.ts
@@ -146,18 +146,21 @@ const tailwindFrame = (
     isJsx
   );
 
+  // Add overflow-hidden class if clipsContent is true
+  const clipsContentClass = node.clipsContent ? " overflow-hidden" : "";
+
   if (node.layoutMode !== "NONE") {
     const rowColumn = tailwindAutoLayoutProps(node, node);
-    return tailwindContainer(node, childrenStr, rowColumn, isJsx);
+    return tailwindContainer(node, childrenStr, rowColumn + clipsContentClass, isJsx);
   } else {
     if (localTailwindSettings.optimizeLayout && node.inferredAutoLayout !== null) {
       const rowColumn = tailwindAutoLayoutProps(node, node.inferredAutoLayout);
-      return tailwindContainer(node, childrenStr, rowColumn, isJsx);
+      return tailwindContainer(node, childrenStr, rowColumn + clipsContentClass, isJsx);
     }
 
     // node.layoutMode === "NONE" && node.children.length > 1
     // children needs to be absolute
-    return tailwindContainer(node, childrenStr, "", isJsx);
+    return tailwindContainer(node, childrenStr, clipsContentClass, isJsx);
   }
 };
 

--- a/packages/backend/src/tailwind/tailwindTextBuilder.ts
+++ b/packages/backend/src/tailwind/tailwindTextBuilder.ts
@@ -97,6 +97,46 @@ export class TailwindTextBuilder extends TailwindDefaultBuilder {
   };
 
   fontFamily = (fontName: FontName): string => {
+    const sansSerif = [
+      'ui-sans-serif',
+      'system-ui',
+      'sans-serif',
+      'Apple Color Emoji',
+      'Segoe UI Emoji',
+      'Segoe UI Symbol',
+      'Noto Color Emoji'
+    ];
+
+    const serif = [
+      'ui-serif',
+      'Georgia',
+      'Cambria',
+      'Times New Roman',
+      'Times',
+      'serif'
+    ];
+
+    const mono = [
+      'ui-monospace',
+      'SFMono-Regular',
+      'Menlo',
+      'Monaco',
+      'Consolas',
+      'Liberation Mono',
+      'Courier New',
+      'monospace'
+    ];
+
+    if (sansSerif.includes(fontName.family)) {
+      return 'font-sans';
+    }
+    if (serif.includes(fontName.family)) {
+      return 'font-serif';
+    }
+    if (mono.includes(fontName.family)) {
+      return 'font-mono';
+    }
+
     return "font-['" + fontName.family + "']";
   };
 


### PR DESCRIPTION
**Added Tailwind class names for serif and monospace fonts.**
When a user selects a specific font family in Figma and it matches the default font family defined in Tailwind, the plugin generates code using Tailwind utility classes.
- https://tailwindcss.com/docs/font-family
- https://imgur.com/39vYDyx (pay attention to the generated code in the plugin)

**Added a Tailwind class for overflow-hidden.**
When the „Clip content“ option is enabled for a frame or component in Figma, the plugin prints the „overflow-hidden“ class in the generated code.
- https://tailwindcss.com/docs/overflow
- https://www.delasign.com/blog/figma-frame-clip-content/
- https://imgur.com/6ruTd5m (can be seen at the end of the video)

**Improved CSS class name generation for custom color names.**
Previously, the plugin generated class names for custom color names in the format „hello-hello world“ if the Figma variable name was „hello/hello world.“ This resulted in two CSS class names.
With this code change, spaces are converted to dashes, ensuring that the Figma variable name „hello/hello world“ generates „hello-hello-world.“

**Added a Figma „documentonchange“ listener.**
The plugin code updates whenever something is updated in the Figma file.
- https://imgur.com/6ruTd5m (pay attention to the generated code in the plugin)